### PR TITLE
feat: add Mux Player

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Demo page: [dev.playerx.io/demo](https://dev.playerx.io/demo/)
 
 ## Supported media
 
+* Mux videos use the [Mux Player API](https://github.com/muxinc/elements/blob/main/packages/mux-player/REFERENCE.md)
 * YouTube videos use the [YouTube iFrame Player API](https://developers.google.com/youtube/iframe_api_reference)
 * Vimeo videos use the [Vimeo Player API](https://developer.vimeo.com/player/sdk)
 * Wistia videos use the [Wistia Player API](https://wistia.com/doc/player-api)
@@ -36,6 +37,7 @@ Demo page: [dev.playerx.io/demo](https://dev.playerx.io/demo/)
 ## Related
 
 - [Media Chrome](https://github.com/muxinc/media-chrome) Your media player's dancing suit. 🕺
+- [`<mux-player>`](https://github.com/muxinc/elements/tree/main/packages/mux-player) The official Mux-flavored video player web component.
 - [`<mux-video>`](https://github.com/muxinc/elements/tree/main/packages/mux-video) A Mux-flavored HTML5 video element w/ hls.js and Mux data builtin.
 - [`<videojs-video>`](https://github.com/luwes/videojs-video-element) A web component for Video.js.
 - [`<wistia-video>`](https://github.com/luwes/wistia-video-element) A web component for the Wistia player.
@@ -43,7 +45,6 @@ Demo page: [dev.playerx.io/demo](https://dev.playerx.io/demo/)
 - [`<jwplayer-video>`](https://github.com/luwes/jwplayer-video-element) A web component for the JW player.
 - [`<hls-video>`](https://github.com/muxinc/hls-video-element) A web component for playing HTTP Live Streaming (HLS) videos.
 - [`castable-video`](https://github.com/muxinc/castable-video) Cast your video element to the big screen with ease!
-- [`<mux-player>`](https://github.com/muxinc/elements/tree/main/packages/mux-player) The official Mux-flavored video player web component.
 
 
 ## Big Thanks

--- a/site/src/_data/players.yaml
+++ b/site/src/_data/players.yaml
@@ -1,3 +1,11 @@
+- key: muxplayer
+  name: Mux
+  url: https://mux.com
+  favicon: /images/mux-logo.png
+  clips:
+    - https://stream.mux.com/r4rOE02cc95tbe3I00302nlrHfT023Q3IedFJW029w018KxZA.m3u8?player=muxplayer
+    - https://bitdash-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8?player=muxplayer
+    - https://stream.mux.com/KHdaCPpki1o4PUCMWfAXFbrHy2gBosxdxZISdvFJGLQ.m3u8?player=muxplayer
 - key: vimeo
   name: Vimeo
   color: '#00ADEF'

--- a/src/playerx/options.js
+++ b/src/playerx/options.js
@@ -18,6 +18,13 @@ export const options = {
       version: '0.0.3',
       jsUrl: '{{npmCdn}}/{{pkg}}@{{version}}/dist/{{pkg}}.js',
     },
+    muxplayer: {
+      pattern: /stream\.mux\.com\/(\w+)|\?player=muxplayer/,
+      type: 'mux-player',
+      pkg: '@mux/mux-player',
+      version: '1.5.1',
+      jsUrl: '{{npmCdn}}/{{pkg}}@{{version}}/dist/mux-player.js',
+    },
     jwplayer: {
       pattern: /jwplayer\.com\/players\/(\w+)(?:-(\w+))?/,
       type: 'jwplayer-video',


### PR DESCRIPTION
Adds the Mux Player as a default option to Playerx.
The API looks already like the native video API so it doesn't need any wrapper custom element 🎉 